### PR TITLE
(maint) Add spec test for airgap install

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,7 +10,7 @@ Gemfile:
   optional:
     ':development':
       - gem: 'bolt'
-        version: '~> 3.0'
+        version: '~> 3.18'
       - gem: 'github_changelog_generator'
         version: '~> 1.15'
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"


### PR DESCRIPTION
Uses fixed `expect_upload` helper in Bolt 3.18 to implement a spec test for installing with an airgap bundle.