### PR TITLE
(maint) Bump to version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,28 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
-## [v0.1.0](https://github.com/puppetlabs/puppetlabs-pam_tools/tree/v0.1.0) (2021-09-22)
+## [v1.0.0](https://github.com/puppetlabs/puppetlabs-pam_tools/tree/v1.0.0) (2021-10-22)
 
-[Full Changelog](https://github.com/puppetlabs/puppetlabs-pam_tools/compare/646d8c7eb638523ce791ccb20df12c84e8b465cf...v0.1.0)
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-pam_tools/compare/v0.1.0...v1.0.0)
 
-### UNCATEGORIZED PRS; LABEL THEM ON GITHUB
+### Added
 
+- \(REPLATS-457\) Add gke cluster support [\#6](https://github.com/puppetlabs/puppetlabs-pam_tools/pull/6) ([jpartlow](https://github.com/jpartlow))
+
+## [v0.1.0](https://github.com/puppetlabs/puppetlabs-pam_tools/tree/v0.1.0) (2021-09-29)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-pam_tools/compare/3b0cbf47115c941274dd7c3b35df2941e2b9b4c5...v0.1.0)
+
+### Added
+
+- \(maint\) Add gemfile lock for Snyk [\#5](https://github.com/puppetlabs/puppetlabs-pam_tools/pull/5) ([jpartlow](https://github.com/jpartlow))
 - \(maint\) Add spec test for airgap install [\#4](https://github.com/puppetlabs/puppetlabs-pam_tools/pull/4) ([MikaelSmith](https://github.com/MikaelSmith))
 - \(REPLATS-427\) Add helm install task [\#3](https://github.com/puppetlabs/puppetlabs-pam_tools/pull/3) ([jpartlow](https://github.com/jpartlow))
-- \(maint\) Update a few task/plan doc references [\#2](https://github.com/puppetlabs/puppetlabs-pam_tools/pull/2) ([jpartlow](https://github.com/jpartlow))
 - \(REPLATS-427\) Add an update\_image task to patch image versions [\#1](https://github.com/puppetlabs/puppetlabs-pam_tools/pull/1) ([jpartlow](https://github.com/jpartlow))
+
+### Fixed
+
+- \(maint\) Update a few task/plan doc references [\#2](https://github.com/puppetlabs/puppetlabs-pam_tools/pull/2) ([jpartlow](https://github.com/jpartlow))
 
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-pam_tools",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "author": "puppetlabs",
   "summary": "Installation and management tasks and plans for Puppet Application Manager.",
   "license": "Apache-2.0",


### PR DESCRIPTION
There are breaking changes from 0.1.0 in:

* pam_tools::kots_install task
  * no longer has a default --skip-preflights=true
  * no longer generates minimal config for connect/comply resource
limits. The caller is expected to provide any configuration beyond the
most basic generated config.
* pam_tools::helm_install_chart
  * no longer takes a +kubeconfig+ parameter; set KUBECONFIG env on the
target instead.