### PR TITLE
(REPLATS-457) Handle ingress for KinD clusters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,10 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
+#ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
+#minor_version = ruby_version_segments[0..1].join('.')
+# Pinning to 2.6 to keep Gemfile.lock static between Ruby versions when using `bundle exec`
+minor_version = '2.6'
 
 group :development do
   gem 'json', '~>2.5',                                           require: false

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -625,7 +625,7 @@ The controller version to install in the cluster.
 
 ##### `provider`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 The provider implementation to use.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -367,6 +367,12 @@ Data type: `Integer`
 
 Seconds to wait for app to scale down to 0 replica before deletion of all related resources.
 
+##### `force`
+
+Data type: `Boolean`
+
+Remove kotsadm even if this looks to be a Kurl cluster.
+
 ### <a name="destroy_nginx_ingress"></a>`destroy_nginx_ingress`
 
 Tear down the Nginx IngressController.

--- a/files/pam_task_helper.rb
+++ b/files/pam_task_helper.rb
@@ -283,6 +283,20 @@ class PAMTaskHelper < TaskHelper
         deleted: deleted,
       }
     end
+
+    # @return [Boolean] true if heuristics indicate that the cluster is a KinD container.
+    def kind_cluster?
+      cmd = [
+        'kubectl',
+        'get',
+        'pod',
+        '--selector=app=kindnet',
+        '--all-namespaces',
+        '--output=name',
+      ]
+      result = run_command(cmd).strip
+      !result.empty?
+    end
   end
 
   include KubectlCommands

--- a/files/pam_task_helper.rb
+++ b/files/pam_task_helper.rb
@@ -139,12 +139,14 @@ class PAMTaskHelper < TaskHelper
       end
     end
 
-    # @return [Array] of Service resource hashes across all namespaces.
-    def get_all_services
+    # @param type [String] resource type to fetch.
+    # @return [Array] of all k8s resource hashes across all namespaces matching
+    # the given +type+.
+    def get_resources(type)
       kots_command = [
         'kubectl',
         'get',
-        'service',
+        type,
         '--all-namespaces',
         '--output=json',
       ]

--- a/files/pam_task_helper.rb
+++ b/files/pam_task_helper.rb
@@ -303,7 +303,7 @@ class PAMTaskHelper < TaskHelper
 
   # Kots command helpers.
   module KotsCommands
-    def kots_app_status(namespace)
+    def kots_app_status(namespace, exit_on_fail: true)
       command = [
         'kubectl-kots',
         'get',
@@ -311,7 +311,7 @@ class PAMTaskHelper < TaskHelper
         "--namespace=#{namespace}",
         '--output=json',
       ]
-      run_command(command)
+      run_command(command, exit_on_fail)
     end
   end
 

--- a/plans/install_published.pp
+++ b/plans/install_published.pp
@@ -105,7 +105,7 @@ plan pam_tools::install_published(
   ##########################################
   # Ensure we have Ingress controllers setup
   # Allows us to later reach the app on http for an eventual health check.
-  # Kurl hosts will have this, gke or kind/k3s/k3d likely will need it installed.
+  # Kurl hosts will have this, gke, k3s or kind likely will need it installed.
   $have_ingress_controllers = run_task('pam_tools::has_ingress_controller', $targets)
   $no_ingress_targets = $have_ingress_controllers.filter_set() |$result| {
     $result.message() == 'false'

--- a/spec/plans/teardown_spec.rb
+++ b/spec/plans/teardown_spec.rb
@@ -60,6 +60,7 @@ describe 'pam_tools::teardown' do
       .with_params(
         'kots_namespace'    => 'default',
         'scaledown_timeout' => 300,
+        'force'             => false,
       )
 
     result = run_plan('pam_tools::teardown', params)

--- a/spec/tasks/delete_kots_app_spec.rb
+++ b/spec/tasks/delete_kots_app_spec.rb
@@ -12,6 +12,15 @@ describe 'pam_tools::delete_kots_app' do
       force: false,
     }
   end
+  let(:kots_is_running) { 'kots is running' }
+
+  before(:each) do
+    expect(task).to(
+      receive(:run_command)
+        .with(include('kubectl-kots', 'get', 'apps'), false)
+        .and_return(kots_is_running)
+    )
+  end
 
   it 'deletes an app' do
     expect(task).to(
@@ -78,7 +87,8 @@ describe 'pam_tools::delete_kots_app' do
         'apps',
         '--namespace=default',
         '--output=json',
-      ]
+      ],
+      true
     ).and_return(apps_hash)
 
     expect(task).to(
@@ -94,5 +104,13 @@ describe 'pam_tools::delete_kots_app' do
         'kubectl-kots remove app2 --namespace=default' => 'deleted',
       }
     )
+  end
+
+  context 'when kotsadm is not installed' do
+    let(:kots_is_running) { 'Error: *message* unable to find kotsadm pod' }
+
+    it 'returns a message rather than failing' do
+      expect(task.task(params)).to eq('kotsadm not found, nothing to do')
+    end
   end
 end

--- a/spec/tasks/delete_kotsadm_spec.rb
+++ b/spec/tasks/delete_kotsadm_spec.rb
@@ -3,16 +3,8 @@
 require 'spec_helper'
 require_relative '../../tasks/delete_kotsadm.rb'
 
-describe 'pam_tools::delete_kotsadm' do
-  let(:task) { DeleteKotsadm.new }
-
-  let(:args) do
-    {
-      kots_namespace: 'default',
-      scaledown_timeout: 300,
-    }
-  end
-  let(:scaleable_response) { '' }
+RSpec.shared_context('deleting kotsadm') do
+  let(:deletion_response) { "message\none deleted\ntwo deleted" }
 
   before(:each) do
     expect(task).to receive(:run_command).with(
@@ -47,9 +39,29 @@ describe 'pam_tools::delete_kotsadm' do
       false
     )
   end
+end
+
+describe 'pam_tools::delete_kotsadm' do
+  let(:task) { DeleteKotsadm.new }
+
+  let(:args) do
+    {
+      kots_namespace: 'default',
+      scaledown_timeout: 300,
+      force: false,
+    }
+  end
+  let(:scaleable_response) { '' }
+  let(:is_kurl) { '' }
+
+  before(:each) do
+    allow(task).to receive(:run_command).with(
+      array_including(['kubectl', 'get', '--selector=app=kurl-proxy-kotsadm'])
+    ).and_return(is_kurl)
+  end
 
   context 'when there is something to delete' do
-    let(:deletion_response) { "message\none deleted\ntwo deleted" }
+    include_context('deleting kotsadm')
 
     it 'deletes the k8s application resources' do
       expect(task.task(args)).to include(
@@ -59,6 +71,33 @@ describe 'pam_tools::delete_kotsadm' do
           'two deleted',
         ],
       )
+    end
+  end
+
+  context 'when this is a kurl host' do
+    let(:is_kurl) { 'pod/kurl-proxy-kotsadm-abcde' }
+
+    it 'skips deleting kotsadm' do
+      expect(task.task(args)).to eq('Kurl detected, skipping...')
+    end
+
+    context 'and forced' do
+      include_context('deleting kotsadm')
+
+      it 'deletes' do
+        args[:force] = true
+        expect(task).not_to receive(:run_command).with(
+          array_including(['kubectl', 'get', '--selector=app=kurl-proxy-kotsadm'])
+        )
+
+        expect(task.task(args)).to include(
+          messages_from_delete: ['message'],
+          deleted: [
+            'one deleted',
+            'two deleted',
+          ],
+        )
+      end
     end
   end
 end

--- a/spec/tasks/get_kots_app_status_spec.rb
+++ b/spec/tasks/get_kots_app_status_spec.rb
@@ -42,7 +42,8 @@ describe 'pam_tools::get_kots_app_status' do
           'apps',
           '--namespace=default',
           '--output=json',
-        ]
+        ],
+        true
       ).and_return(apps_hash)
     end
 

--- a/spec/tasks/has_ingress_controller_spec.rb
+++ b/spec/tasks/has_ingress_controller_spec.rb
@@ -5,22 +5,26 @@ require_relative '../../tasks/has_ingress_controller.rb'
 
 describe 'pam_tools::has_ingress_controller' do
   let(:task) { HasIngressController.new }
+  let(:pods) { nil }
 
   context '#task' do
-    let(:kind) { '' }
-
     before(:each) do
       expect(task).to receive(:run_command).with(
         include('kubectl', 'get', 'service')
       ).and_return({
         items: services
       }.to_json)
-      expect(task).to receive(:run_command).with(
-        include('kubectl', 'get', 'pod')
-      ).and_return(kind)
+
+      if !pods.nil?
+        expect(task).to receive(:run_command).with(
+          include('kubectl', 'get', 'pod')
+        ).and_return({
+          items: pods
+        }.to_json)
+      end
     end
 
-    context 'with LoadBalancer' do
+    context 'with LoadBalancer service' do
       let(:services) do
         [
           {
@@ -41,7 +45,7 @@ describe 'pam_tools::has_ingress_controller' do
       end
     end
 
-    context 'with NodePort' do
+    context 'with NodePort service' do
       let(:services) do
         [
           {
@@ -62,17 +66,19 @@ describe 'pam_tools::has_ingress_controller' do
       end
     end
 
-    context 'with a KinD NodePort' do
-      let(:kind) { 'pod/kindnet-abcde' }
-      let(:services) do
+    context 'with a pod hostPort' do
+      let(:services) { [] }
+      let(:pods) do
         [
           {
             spec: {
-              type: 'NodePort',
-              ports: [
+              containers: [
                 {
-                  port: 80,
-                  nodePort: 30_000,
+                  ports: [
+                    {
+                      hostPort: 80,
+                    },
+                  ],
                 },
               ],
             },
@@ -120,6 +126,42 @@ describe 'pam_tools::has_ingress_controller' do
           },
         ]
       end
+      let(:pods) do
+        [
+          {
+            spec: {
+              containers: [
+                {
+                  ports: [
+                    {
+                      hostPort: 3000,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ]
+      end
+
+      it 'returns true' do
+        expect(task.task).to eq(false)
+      end
+    end
+
+    context 'with containers without ports' do
+      let(:services) { [] }
+      let(:pods) do
+        [
+          {
+            spec: {
+              containers: [
+                {},
+              ],
+            },
+          },
+        ]
+      end
 
       it 'returns true' do
         expect(task.task).to eq(false)
@@ -128,6 +170,7 @@ describe 'pam_tools::has_ingress_controller' do
 
     context 'with nothing' do
       let(:services) { [] }
+      let(:pods) { [] }
 
       it 'returns true' do
         expect(task.task).to eq(false)

--- a/tasks/delete_kots_app.rb
+++ b/tasks/delete_kots_app.rb
@@ -5,6 +5,11 @@ require_relative '../files/pam_task_helper.rb'
 # Delete a Replicated app from the admin-console.
 class DeleteKotsApp < PAMTaskHelper
 
+  def kotsadm_installed?(namespace)
+    running = kots_app_status(namespace, exit_on_fail: false).strip
+    running !~ %r{Error.*unable to find kotsadm pod}
+  end
+
   def get_all_registered(namespace)
     kots_app_status(namespace).map do |s|
       s['slug']
@@ -12,22 +17,24 @@ class DeleteKotsApp < PAMTaskHelper
   end
 
   def task(kots_slug:, kots_namespace:, force:, **_kwargs)
-    to_delete = (kots_slug == '*') ?
-      get_all_registered(kots_namespace) :
-      Array(kots_slug)
+    if kotsadm_installed?(kots_namespace)
+      to_delete = (kots_slug == '*') ?
+        get_all_registered(kots_namespace) :
+        Array(kots_slug)
 
-    delete_output = to_delete.each_with_object({}) do |slug, hash|
-      delete_command = [
-        'kubectl-kots',
-        'remove',
-        slug,
-        "--namespace=#{kots_namespace}",
-      ]
-      delete_command << '--force' if force
-      hash[delete_command.join(' ')] = run_command(delete_command)
+      to_delete.each_with_object({}) do |slug, hash|
+        delete_command = [
+          'kubectl-kots',
+          'remove',
+          slug,
+          "--namespace=#{kots_namespace}",
+        ]
+        delete_command << '--force' if force
+        hash[delete_command.join(' ')] = run_command(delete_command)
+      end
+    else
+      'kotsadm not found, nothing to do'
     end
-
-    delete_output
   end
 end
 

--- a/tasks/delete_kotsadm.json
+++ b/tasks/delete_kotsadm.json
@@ -14,6 +14,11 @@
       "description": "Seconds to wait for app to scale down to 0 replica before deletion of all related resources.",
       "type": "Integer",
       "default": 300
+    },
+    "force": {
+      "description": "Remove kotsadm even if this looks to be a Kurl cluster.",
+      "type": "Boolean",
+      "default": false
     }
   }
 }

--- a/tasks/delete_kotsadm.rb
+++ b/tasks/delete_kotsadm.rb
@@ -5,20 +5,40 @@ require_relative '../files/pam_task_helper.rb'
 # Delete the Kots admin-console application from the cluster.
 class DeleteKotsadm < PAMTaskHelper
 
-  def task(kots_namespace:, scaledown_timeout:, **_kwargs)
-    selector = 'kots.io/kotsadm=true'
+  # @return [Boolean] true if we detect a kurl-proxy pod running, which is an
+  # in-cluster guess for this having been set up by Kurl.
+  def kurl_cluster?(kots_namespace)
+    get_kurl_proxy_pod_command = [
+      'kubectl',
+      'get',
+      'pod',
+      "--namespace=#{kots_namespace}",
+      '--selector=app=kurl-proxy-kotsadm',
+      '--output=name',
+    ]
+    !run_command(get_kurl_proxy_pod_command).empty?
+  end
 
-    # Attempt to scale down before deletion.
-    scaledown_results = scale_down(kots_namespace, selector, scaledown_timeout)
-    delete_results = delete_resources(kots_namespace, selector)
+  def task(kots_namespace:, scaledown_timeout:, force:, **_kwargs)
+    # Skip deleting kotsadm if this is a Kurl cluster, because reinstalling
+    # Kots will not set the kurl-proxy back up. Do it anyway if told to.
+    if force || !kurl_cluster?(kots_namespace)
+      selector = 'kots.io/kotsadm=true'
 
-    # Clean up a secret that's not caught by the above selector (if it
-    # exists).
-    delete_secret_results = run_command(['kubectl', 'delete', 'secret/kotsadm-replicated-registry'], false)
+      # Attempt to scale down before deletion.
+      scaledown_results = scale_down(kots_namespace, selector, scaledown_timeout)
+      delete_results = delete_resources(kots_namespace, selector)
 
-    {
-      delete_registry_secret_output: delete_secret_results,
-    }.merge(scaledown_results).merge(delete_results)
+      # Clean up a secret that's not caught by the above selector (if it
+      # exists).
+      delete_secret_results = run_command(['kubectl', 'delete', 'secret/kotsadm-replicated-registry'], false)
+
+      {
+        delete_registry_secret_output: delete_secret_results,
+      }.merge(scaledown_results).merge(delete_results)
+    else
+      'Kurl detected, skipping...'
+    end
   end
 end
 

--- a/tasks/get_ingress_ip.rb
+++ b/tasks/get_ingress_ip.rb
@@ -13,7 +13,7 @@ class GetIngressIP < PAMTaskHelper
   end
 
   def get_load_balancer_ip(port)
-    services = get_all_services
+    services = get_resources('service')
     lb = get_load_balancer_for_port(services, port)
 
     return unless lb

--- a/tasks/has_ingress_controller.rb
+++ b/tasks/has_ingress_controller.rb
@@ -8,15 +8,16 @@ class HasIngressController < PAMTaskHelper
     spec['type'] == 'LoadBalancer' && spec['ports'].any? { |p| p['port'] == port }
   end
 
-  def node_port?(spec, port)
-    spec['type'] == 'NodePort' && spec['ports'].any? { |p| p['nodePort'] == port }
+  def node_port?(spec, port, port_param)
+    spec['type'] == 'NodePort' && spec['ports'].any? { |p| p[port_param] == port }
   end
 
   def task(**_kwargs)
     services = get_all_services
+    node_port_parameter = kind_cluster? ? 'port' : 'nodePort'
 
     services.any? do |service|
-      lb_port?(service['spec'], 80) || node_port?(service['spec'], 80)
+      lb_port?(service['spec'], 80) || node_port?(service['spec'], 80, node_port_parameter)
     end
   end
 end

--- a/tasks/has_ingress_controller.rb
+++ b/tasks/has_ingress_controller.rb
@@ -2,23 +2,37 @@
 
 require_relative '../files/pam_task_helper.rb'
 
-# Return true if an lb or nodeport service exists for the given port.
+# Return true if an lb or nodeport service or pod with hostPort exists for the given port.
 class HasIngressController < PAMTaskHelper
   def lb_port?(spec, port)
     spec['type'] == 'LoadBalancer' && spec['ports'].any? { |p| p['port'] == port }
   end
 
-  def node_port?(spec, port, port_param)
-    spec['type'] == 'NodePort' && spec['ports'].any? { |p| p[port_param] == port }
+  def node_port?(spec, port)
+    spec['type'] == 'NodePort' && spec['ports'].any? { |p| p['nodePort'] == port }
+  end
+
+  def host_port?(pod, port)
+    containers = pod['spec']['containers']
+    containers.any? do |c|
+      (c['ports'] || []).any? { |p| p['hostPort'] == port }
+    end
   end
 
   def task(**_kwargs)
-    services = get_all_services
-    node_port_parameter = kind_cluster? ? 'port' : 'nodePort'
+    services = get_resources('service')
 
-    services.any? do |service|
-      lb_port?(service['spec'], 80) || node_port?(service['spec'], 80, node_port_parameter)
+    service_ingress = services.any? do |service|
+      lb_port?(service['spec'], 80) || node_port?(service['spec'], 80)
     end
+
+    pod_ingress = false
+    if !service_ingress
+      pods = get_resources('pod')
+      pod_ingress = pods.any? { |pod| host_port?(pod, 80) }
+    end
+
+    service_ingress || pod_ingress
   end
 end
 

--- a/tasks/start_nginx_ingress.json
+++ b/tasks/start_nginx_ingress.json
@@ -12,8 +12,7 @@
     },
     "provider": {
       "description": "The provider implementation to use.",
-      "type": "String",
-      "default": "cloud"
+      "type": "Optional[String]"
     },
     "timeout": {
       "description": "Number of secs to wait for controller to be ready.",

--- a/tasks/start_nginx_ingress.rb
+++ b/tasks/start_nginx_ingress.rb
@@ -5,7 +5,8 @@ require_relative '../files/pam_task_helper.rb'
 # Start an Nginx IngressController.
 class StartNginxIngress < PAMTaskHelper
 
-  def task(version:, provider:, timeout:, **_kwargs)
+  def task(version:, timeout:, provider: nil, **_kwargs)
+    provider ||= kind_cluster? ? 'kind' : 'cloud'
     source_url = "https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v#{version}/deploy/static/provider/#{provider}/deploy.yaml"
     apply_command = [
       'kubectl',

--- a/tasks/wait_for_app.sh
+++ b/tasks/wait_for_app.sh
@@ -49,14 +49,15 @@ http_ok_within() {
 
 check_return_code() {
     protocol=$1
-    curl --insecure --location --silent --output /dev/null --write-out '%{http_code}' "${protocol}://${app_hostname}"
+    timeout "$2" bash -c \
+      "curl --insecure --location --silent --output /dev/null --write-out '%{http_code}' ${protocol}://${app_hostname}"
 }
 
 if ! http_ok_within "${HTTP_TIMEOUT}"; then
     echo
     echo "http/s return codes not 200 within timeout"
-    echo "https returned: $(check_return_code https)"
-    echo "http returned: $(check_return_code http)"
+    echo "https returned: $(check_return_code https "${HTTP_TIMEOUT}")"
+    echo "http returned: $(check_return_code http "${HTTP_TIMEOUT}")"
     echo
     echo "kubectl get pods:"
     kubectl -n "${KOTS_NAMESPACE}" get pods -A;


### PR DESCRIPTION
* Handles KinD specific ingress check and start ingress needs
* Makes pam_tools::delete_kots_app idempotent if kotsadm not present
* Makes pam_tools::delete_kotsadm skip Kurl hosts unless forced
* Fixes some README toc markdown

You still get an error if you re-run delete_kots_app for a non-existent slug when kotsadm is still running, but I'm not going to worry about that right now.