### PR TITLE
(REPLATS-536) Add webhook_hostname

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -813,6 +813,7 @@ The following parameters are available in the `pam_tools::install_published` pla
 * [`config_file`](#config_file)
 * [`airgap_bundle`](#airgap_bundle)
 * [`hostname`](#hostname)
+* [`webhook_hostname`](#webhook_hostname)
 * [`kots_install_options`](#kots_install_options)
 * [`pam_variant`](#pam_variant)
 * [`allocated_memory_in_gigabytes`](#allocated_memory_in_gigabytes)
@@ -866,6 +867,15 @@ Data type: `Optional[String]`
 The application hostname to set in a generated configuration. Ignored if
 +config_file+ given. Otherwise generated from target if not set (see
 above).
+
+Default value: ``undef``
+
+##### <a name="webhook_hostname"></a>`webhook_hostname`
+
+Data type: `Optional[String]`
+
+For applications that present a webhook, hosts the webhook on a separate
+Ingress at the specified hostname rather than an external port.
 
 Default value: ``undef``
 

--- a/spec/plans/install_published_spec.rb
+++ b/spec/plans/install_published_spec.rb
@@ -120,6 +120,7 @@ describe 'pam_tools::install_published' do
       )
     expect_out_message.with_params('  ** Target: spec-host')
     expect_out_message.with_params('  **   connect hostname: spec-host')
+    expect_out_message.with_params('  **   connect webhook: spec-host:8000')
     expect_out_message.with_params('  **   connect root login: noreply@puppet.com')
 
     result = run_plan('pam_tools::install_published', params)
@@ -225,6 +226,14 @@ describe 'pam_tools::install_published' do
         .with_targets(['localhost'])
         .always_return('_output' => '10.20.30.40')
       expect_out_message.with_params('  **   connect hostname: my.app.host')
+
+      result = run_plan('pam_tools::install_published', params)
+      expect(result.ok?).to eq(true)
+    end
+
+    it 'uses webhook hostname' do
+      params['webhook_hostname'] = 'webhook.app.host'
+      expect_out_message.with_params('  **   connect webhook: webhook.app.host:443')
 
       result = run_plan('pam_tools::install_published', params)
       expect(result.ok?).to eq(true)

--- a/templates/default-app-config.yaml.epp
+++ b/templates/default-app-config.yaml.epp
@@ -1,6 +1,7 @@
 <%- |
   String $kots_app,
   String $hostname,
+  Optional[String] $webhook_hostname = undef,
   Optional[String] $password = undef,
   Variant[Float,Integer] $allocated_memory_in_gigabytes = 16,
   Variant[Float,Integer] $allocated_cpu = 8,
@@ -24,6 +25,10 @@ spec:
   <%- if ($password =~ NotUndef) { -%>
     root_password:
       value: <%= $password %>
+  <%- } -%>
+  <%- if ($webhook_hostname =~ NotUndef) { -%>
+    backend_hostname:
+      value: '<%= $webhook_hostname %>'
   <%- } -%>
 <% } -%>
 <%-


### PR DESCRIPTION
Adds a `webhook_hostname` parameter to use an ingress rather than expose a separate port for the webhook endpoint in apps that have one.