### PR TITLE
(REPLATS-487) Add plan to install helm charts

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -47,6 +47,19 @@ jobs:
           bolt task run pam_tools::delete_k8s_app_resources --targets=localhost kots_slug=test-chart
       - uses: ./.github/actions/validate-no-pods
 
+  plan-helm-acceptance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nolar/setup-k3d-k3s@v1
+        with:
+          version: v1.19
+          k3d-args: -p 80:80@loadbalancer -p 443:443@loadbalancer
+      - uses: ./.github/actions/install-bolt
+      - name: Install bitnami/metrics-server chart
+        run: |-
+          bolt plan run pam_tools::install_chart --targets=localhost chart_name=bitnami/metrics-server repository_uri=https://charts.bitnami.com/bitnami release='test-release' values_yaml='commonLabels: { app.kubernetes.io/part-of: metrics-server }' part_of=metrics-server
+
   plan-install-acceptance:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In particular, the target you run bolt against should have:
 * [kubectl]
 * [kubectl-kots]
 * [ruby] \(because most of the tasks are Ruby\)
-* [helm] \(optional, depending on whether you installing helm charts\)
+* [helm] \(optional, depending on whether you are installing helm charts\)
 
 installed.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -27,6 +27,7 @@
 * [`get_ingress_ip`](#get_ingress_ip): Returns the ip of the ingress load balancer service.
 * [`get_kots_app_status`](#get_kots_app_status): Return the state of a given Kots application, or not-installed. Will also return not-installed if kots itself is not installed.
 * [`has_ingress_controller`](#has_ingress_controller): Checks whether an ingress controller is installed.
+* [`helm_add_repository`](#helm_add_repository): Add a helm repository.
 * [`helm_install_chart`](#helm_install_chart): Install or upgrade a helm chart.
 * [`kots_download`](#kots_download): Downloads the currently installed source of a given Kots application from the admin console to the given directory. This task is a wrapper ro
 * [`kots_install`](#kots_install): Install a Replicated application with kubectl-kots for testing. This task takes several shortcuts for configuration and security which are no
@@ -40,6 +41,7 @@
 
 ### Plans
 
+* [`pam_tools::install_chart`](#pam_toolsinstall_chart): Install a helm chart.  Optionally adds a helm *repository_uri* before installing.  Optionally waits for rollout of the installed chart based 
 * [`pam_tools::install_published`](#pam_toolsinstall_published): Install a published Replicated application via kubectl-kots.  Runs kubectl-kots with the given license and configuration and waits for deploy
 * [`pam_tools::teardown`](#pam_toolsteardown): In successive tiers, teardown the application, it's admin-console metadata, and the Kots admin-console itself, if desired.  By default, just 
 
@@ -432,6 +434,26 @@ Checks whether an ingress controller is installed.
 
 **Supports noop?** false
 
+### <a name="helm_add_repository"></a>`helm_add_repository`
+
+Add a helm repository.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `repository_name`
+
+Data type: `String`
+
+Name for the helm repository.
+
+##### `repository_uri`
+
+Data type: `String`
+
+Uri for the helm repository.
+
 ### <a name="helm_install_chart"></a>`helm_install_chart`
 
 Install or upgrade a helm chart.
@@ -759,6 +781,89 @@ Data type: `Pattern[/[0-9]+s/]`
 Number of seconds to wait for Deployment and StatefulSet rollouts to complete.
 
 ## Plans
+
+### <a name="pam_toolsinstall_chart"></a>`pam_tools::install_chart`
+
+Install a helm chart.
+
+Optionally adds a helm *repository_uri* before installing.
+
+Optionally waits for rollout of the installed chart based on a
+*part_of* selector.
+
+#### Parameters
+
+The following parameters are available in the `pam_tools::install_chart` plan:
+
+* [`targets`](#targets)
+* [`chart_name`](#chart_name)
+* [`release`](#release)
+* [`repository_uri`](#repository_uri)
+* [`values_yaml`](#values_yaml)
+* [`namespace`](#namespace)
+* [`part_of`](#part_of)
+* [`timeout`](#timeout)
+
+##### <a name="targets"></a>`targets`
+
+Data type: `TargetSpec`
+
+Test hosts to deploy to.
+
+##### <a name="chart_name"></a>`chart_name`
+
+Data type: `String`
+
+The chart to install.
+
+##### <a name="release"></a>`release`
+
+Data type: `String`
+
+The name of the installed instance of the chart.
+
+##### <a name="repository_uri"></a>`repository_uri`
+
+Data type: `Optional[String]`
+
+If a helm repository uri is given, ensure it is added and updated on targets
+before attempting to install the chart. Will take the repository name from
+the *chart_name* prefix/.
+
+Default value: ``undef``
+
+##### <a name="values_yaml"></a>`values_yaml`
+
+Data type: `Optional[String]`
+
+Optional yaml string of chart values to pass to Helm.
+
+Default value: ``undef``
+
+##### <a name="namespace"></a>`namespace`
+
+Data type: `String`
+
+k8s namespace we're installing into.
+
+Default value: `'default'`
+
+##### <a name="part_of"></a>`part_of`
+
+Data type: `Optional[String]`
+
+If given, plan will wait for rollout of deployments and statefulsets
+matching 'app.kuberneters.io/part-of=${part_of}' until *timeout*.
+
+Default value: ``undef``
+
+##### <a name="timeout"></a>`timeout`
+
+Data type: `Integer`
+
+Number of seconds to wait for the services to all be ready.
+
+Default value: `600`
 
 ### <a name="pam_toolsinstall_published"></a>`pam_tools::install_published`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -57,18 +57,18 @@ minimal test memory instance of 4.5GB.
 This allows you to spin up Connect on an 8GB test host with the PE
 components squeezed down into:
 
-  pam_tools::calculate_pe_memory(4.5)
-  #
-  # {
-  #   'console_memory'           => 768,
-  #   'postgres_console_memory'  => 256,
-  #   'puppetdb_memory'          => 768,
-  #   'postgres_puppetdb_memory' => 512,
-  #   'orchestrator_memory'      => 768,
-  #   'postgres_orch_memory'     => 256,
-  #   'boltserver_memory'        => 256,
-  #   'puppetserver_memory'      => 1024,
-  # }
+    pam_tools::calculate_pe_memory(4.5)
+    #
+    # {
+    #   'console_memory'           => 768,
+    #   'postgres_console_memory'  => 256,
+    #   'puppetdb_memory'          => 768,
+    #   'postgres_puppetdb_memory' => 512,
+    #   'orchestrator_memory'      => 768,
+    #   'postgres_orch_memory'     => 256,
+    #   'boltserver_memory'        => 256,
+    #   'puppetserver_memory'      => 1024,
+    # }
 
 Leaving remaining memory for the rest of Connect and system.
 
@@ -86,18 +86,18 @@ minimal test memory instance of 4.5GB.
 This allows you to spin up Connect on an 8GB test host with the PE
 components squeezed down into:
 
-  pam_tools::calculate_pe_memory(4.5)
-  #
-  # {
-  #   'console_memory'           => 768,
-  #   'postgres_console_memory'  => 256,
-  #   'puppetdb_memory'          => 768,
-  #   'postgres_puppetdb_memory' => 512,
-  #   'orchestrator_memory'      => 768,
-  #   'postgres_orch_memory'     => 256,
-  #   'boltserver_memory'        => 256,
-  #   'puppetserver_memory'      => 1024,
-  # }
+    pam_tools::calculate_pe_memory(4.5)
+    #
+    # {
+    #   'console_memory'           => 768,
+    #   'postgres_console_memory'  => 256,
+    #   'puppetdb_memory'          => 768,
+    #   'postgres_puppetdb_memory' => 512,
+    #   'orchestrator_memory'      => 768,
+    #   'postgres_orch_memory'     => 256,
+    #   'boltserver_memory'        => 256,
+    #   'puppetserver_memory'      => 1024,
+    # }
 
 Leaving remaining memory for the rest of Connect and system.
 

--- a/functions/calculate_pe_memory.pp
+++ b/functions/calculate_pe_memory.pp
@@ -4,18 +4,18 @@
 # This allows you to spin up Connect on an 8GB test host with the PE
 # components squeezed down into:
 #
-#   pam_tools::calculate_pe_memory(4.5)
-#   #
-#   # {
-#   #   'console_memory'           => 768,
-#   #   'postgres_console_memory'  => 256,
-#   #   'puppetdb_memory'          => 768,
-#   #   'postgres_puppetdb_memory' => 512,
-#   #   'orchestrator_memory'      => 768,
-#   #   'postgres_orch_memory'     => 256,
-#   #   'boltserver_memory'        => 256,
-#   #   'puppetserver_memory'      => 1024,
-#   # }
+#     pam_tools::calculate_pe_memory(4.5)
+#     #
+#     # {
+#     #   'console_memory'           => 768,
+#     #   'postgres_console_memory'  => 256,
+#     #   'puppetdb_memory'          => 768,
+#     #   'postgres_puppetdb_memory' => 512,
+#     #   'orchestrator_memory'      => 768,
+#     #   'postgres_orch_memory'     => 256,
+#     #   'boltserver_memory'        => 256,
+#     #   'puppetserver_memory'      => 1024,
+#     # }
 #
 # Leaving remaining memory for the rest of Connect and system.
 #

--- a/plans/install_chart.pp
+++ b/plans/install_chart.pp
@@ -1,0 +1,75 @@
+# Install a helm chart.
+#
+# Optionally adds a helm *repository_uri* before installing.
+#
+# Optionally waits for rollout of the installed chart based on a
+# *part_of* selector.
+#
+# @param targets
+#   Test hosts to deploy to.
+# @param chart_name
+#   The chart to install.
+# @param release
+#   The name of the installed instance of the chart.
+# @param repository_uri
+#   If a helm repository uri is given, ensure it is added and updated on targets
+#   before attempting to install the chart. Will take the repository name from
+#   the *chart_name* prefix/.
+# @param values_yaml
+#   Optional yaml string of chart values to pass to Helm.
+# @param namespace
+#   k8s namespace we're installing into.
+# @param part_of
+#   If given, plan will wait for rollout of deployments and statefulsets
+#   matching 'app.kuberneters.io/part-of=${part_of}' until *timeout*.
+# @param timeout
+#   Number of seconds to wait for the services to all be ready.
+plan pam_tools::install_chart(
+  TargetSpec $targets,
+  String $chart_name,
+  String $release,
+  Optional[String] $repository_uri = undef,
+  Optional[String] $values_yaml = undef,
+  String $namespace = 'default',
+  Optional[String] $part_of = undef,
+  Integer $timeout = 600,
+) {
+
+  if $repository_uri =~ NotUndef {
+    $repository_name = regsubst($chart_name, '^([\w-]+)/[\w-]+$', '\1')
+    # regsubst() returns the string unchanged if it does not match.
+    if $repository_name == $chart_name {
+      fail_plan("Expected to find a repository name as the prefix/ in chart_name: '${chart_name}'. Therefore unable to add repository uri '${repository_uri}'.")
+    }
+    $repo_results = run_task('pam_tools::helm_add_repository', $targets, {
+      repository_name => $repository_name,
+      repository_uri  => $repository_uri,
+    })
+  } else {
+    $repo_results = 'No repository to add.'
+  }
+
+  $install_results = run_task('pam_tools::helm_install_chart', $targets, {
+    chart      => $chart_name,
+    release    => $release,
+    values     => $values_yaml,
+    namespace  => $namespace,
+  })
+
+  if $part_of =~ NotUndef {
+    $wait_results = run_task('pam_tools::wait_for_rollout', $targets, {
+      selector  => "app.kubernetes.io/part-of=${part_of}",
+      namespace => $namespace,
+      timeout   => "${timeout}s",
+    })
+  } else {
+    $wait_results = 'No part_of selector specified; not waiting for rollout.'
+  }
+
+  $results = {
+    repo_results    => $repo_results,
+    install_results => $install_results,
+    wait_results    => $wait_results,
+  }
+  return $results
+}

--- a/spec/plans/install_chart_spec.rb
+++ b/spec/plans/install_chart_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'pam_tools::install_chart' do
+  # Include the BoltSpec library functions
+  include BoltSpec::Plans
+
+  let(:targets) { ['spec-host'] }
+  let(:params) do
+    {
+      'targets'    => targets,
+      'chart_name' => 'test-chart',
+      'release'    => 'a-release',
+    }
+  end
+
+  it 'installs a chart' do
+    expect_task('pam_tools::helm_install_chart')
+      .with_targets(targets)
+      .with_params(
+        'chart'      => 'test-chart',
+        'release'    => 'a-release',
+        'values'     => nil,
+        'namespace'  => 'default',
+      )
+      .always_return('results' => 'installed')
+
+    result = run_plan('pam_tools::install_chart', params)
+    expect(result.ok?).to eq(true)
+    expect(result.value['repo_results']).to eq('No repository to add.')
+    expect(result.value['wait_results']).to match(%r{No part_of selector specified})
+  end
+
+  it 'adds a repository then installs a chart' do
+    params['repository_uri'] = 'https://a.repo.rspec'
+    params['chart_name'] = 'arepo/test-chart'
+
+    expect_task('pam_tools::helm_add_repository')
+      .with_targets(targets)
+      .with_params(
+        'repository_name' => 'arepo',
+        'repository_uri'  => 'https://a.repo.rspec',
+      )
+      .always_return('_output' => 'added arepo')
+
+    expect_task('pam_tools::helm_install_chart')
+      .with_targets(targets)
+      .with_params(
+        'chart'      => 'arepo/test-chart',
+        'release'    => 'a-release',
+        'values'     => nil,
+        'namespace'  => 'default',
+      )
+      .always_return('results' => 'installed')
+
+    result = run_plan('pam_tools::install_chart', params)
+    expect(result.ok?).to eq(true)
+    expect(result.value['repo_results']).to be_kind_of(Bolt::ResultSet)
+    expect(result.value['wait_results']).to match(%r{No part_of selector specified})
+  end
+
+  it 'fails if repository_uri is given but chart_name has no prefix' do
+    params['repository_uri'] = 'https://a.repo.rspec'
+
+    result = run_plan('pam_tools::install_chart', params)
+    expect(result.ok?).to eq(false)
+    expect(result.value.message).to match(%r{Expected to find a repository name})
+  end
+
+  it 'installs a chart then waits' do
+    params['part_of'] = 'stuff'
+
+    expect_task('pam_tools::helm_install_chart')
+    expect_task('pam_tools::wait_for_rollout')
+      .with_targets(targets)
+      .with_params(
+        'selector'  => 'app.kubernetes.io/part-of=stuff',
+        'namespace' => 'default',
+        'timeout'   => '600s',
+      )
+      .always_return('_output' => 'running')
+
+    result = run_plan('pam_tools::install_chart', params)
+    expect(result.ok?).to eq(true)
+    expect(result.value['repo_results']).to eq('No repository to add.')
+    expect(result.value['wait_results']).to be_kind_of(Bolt::ResultSet)
+  end
+end

--- a/tasks/helm_add_repository.json
+++ b/tasks/helm_add_repository.json
@@ -1,0 +1,14 @@
+{
+  "description": "Add a helm repository.",
+  "input_method": "environment",
+  "parameters": {
+    "repository_name": {
+      "description": "Name for the helm repository.",
+      "type": "String"
+    },
+    "repository_uri": {
+      "description": "Uri for the helm repository.",
+      "type": "String"
+    }
+  } 
+}

--- a/tasks/helm_add_repository.sh
+++ b/tasks/helm_add_repository.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+# PT_* are passed into the environment by Bolt.
+# shellcheck disable=SC2154
+repo_name="${PT_repository_name}"
+repo_uri="${PT_repository_uri}"
+
+helm repo add "${repo_name}" "${repo_uri}"
+helm repo update


### PR DESCRIPTION
Generic plan for installing helm charts that handles adding a local helm
repository first, if required, and waiting for the deployments and
statefulsets to rollout if a selector is specified.