### PR TITLE
(REPLATS-557) Add accept_beta_agreement for Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Bolt module providing tasks and plans for installing and managing Puppet Applica
 
 Tooling to assist with installation and removal of [PAM] applications in a k8s cluster. The tasks are wrappers around kubectl and kubectl-kots invocations, and assume the existance of a compatible k8s cluster providing for the application requirements.
 
+By installing via these tools, unless Puppet has otherwise agreed in writing, all software is subject to the terms and conditions of Puppet's Master License Agreement located at https://puppet.com/legal. Additionally when installing Connect, you accept the [Puppet Beta Agreement](https://s3.amazonaws.com/pe-builds/previews/2019+02+Puppet+Beta+Agreement+(On-Prem+Software).pdf).
+
 Compatible with the following cluster types:
 
 * [kURL], specifically [puppet-application-manager-standalone]; not yet tested with a [puppet-application-manager] HA cluster.

--- a/spec/classes/default_app_config_yaml_spec.rb
+++ b/spec/classes/default_app_config_yaml_spec.rb
@@ -127,6 +127,7 @@ describe 'pam_tools::test_default_app_config_template' do
             'hostname' => { 'value' => 'test.rspec' },
             'analytics' => { 'value' => '0' },
             'accept_eula' => { 'value' => 'has_accepted_eula' },
+            'accept_beta_agreement' => { 'value' => 'has_accepted_beta_agreement' },
             'root_email' => { 'value' => 'noreply@puppet.com' },
             'root_password' => { 'value' => 'password' },
             'connect_postgres_console_memory' => { 'value' => '455' },

--- a/spec/classes/default_app_config_yaml_spec.rb
+++ b/spec/classes/default_app_config_yaml_spec.rb
@@ -61,8 +61,8 @@ describe 'pam_tools::test_default_app_config_template' do
             'hostname' => { 'value' => 'test.rspec' },
             'analytics' => { 'value' => '0' },
             'accept_eula' => { 'value' => 'has_accepted_eula' },
-             'root_email' => { 'value' => 'noreply@puppet.com' },
-             'root_password' => { 'value' => 'password' },
+            'root_email' => { 'value' => 'noreply@puppet.com' },
+            'root_password' => { 'value' => 'password' },
           }
         }
       }

--- a/spec/plans/install_published_spec.rb
+++ b/spec/plans/install_published_spec.rb
@@ -47,6 +47,8 @@ describe 'pam_tools::install_published' do
             value: 'noreply@puppet.com'
           root_password:
             value: #{password}
+          accept_beta_agreement:
+            value: 'has_accepted_beta_agreement'
           connect_postgres_console_memory:
             value: '#{mem_unit}'
           connect_postgres_puppetdb_memory:

--- a/tasks/kots_install.rb
+++ b/tasks/kots_install.rb
@@ -64,6 +64,11 @@ class KotsInstall < PAMTaskHelper
     config = base_config(appname, hostname)
     spec_values = config['spec']['values']
     spec_values.merge!(root_account_config(appname, password))
+    if appname == 'connect'
+      spec_values['accept_beta_agreement'] = {
+        'value' => 'has_accepted_beta_agreement',
+      }
+    end
 
     config
   end

--- a/templates/default-app-config.yaml.epp
+++ b/templates/default-app-config.yaml.epp
@@ -36,6 +36,8 @@ if ($kots_app == 'connect') {
   # Allocate half the available to PE.
   $memory_allocation = pam_tools::calculate_pe_memory($allocated_memory_in_gigabytes / 2)
 -%>
+    accept_beta_agreement:
+      value: 'has_accepted_beta_agreement'
     connect_postgres_console_memory:
       value: '<%= $memory_allocation['postgres_console_memory'] %>'
     connect_postgres_puppetdb_memory:


### PR DESCRIPTION
Adds the `accept_beta_agreement` acknowledgement when installing Puppet Connect. Also includes a notice in the README about agreements that are implicitly accepted when using these tools.