### PR TITLE
(maint) Update license reference in github action

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -6,7 +6,7 @@ on:
     - main
 
 env:
-  # https://vendor.replicated.com/apps/cd4pe/customer/1liKeLfya3YPpuSoQUAmDLQ4BeL/manage
+  # https://vendor.replicated.com/apps/cd4pe/customer/1gI7fCMJ1uCogFlaSQnTFtVJpjW/manage
   CD4PE_LICENSE: ${{ secrets.CD4PE_LICENSE }}
   KUBECTL_VERSION: v1.22.2
   KOTS_VERSION: v1.52.0


### PR DESCRIPTION
When I switched the license to CD4PE I forgot to update the string
pointing back to the relevant replicated license.